### PR TITLE
Add new extensions apr2024

### DIFF
--- a/armory.json
+++ b/armory.json
@@ -878,6 +878,12 @@
             "command_name": "patchit",
             "repo_url": "https://github.com/sliverarmory/BOF-patchit",
             "public_key": "RWQhRUp9UkE8nXlKTw+hpTg8fm0kJQpNDXy0gTpS/3Uw6+TPjM6jlxhy"
+        },
+        {
+            "name": "threadless-inject",
+            "command_name": "threadless-inject",
+            "repo_url": "https://github.com/sliverarmory/ThreadlessInject-BOF",
+            "public_key": "RWQb8kihJmahzcrXdqyTgIzOlKOGkMy41Jw99LgbLIPP/fumtFxN5nGc"
         }
     ],
     "bundles": [
@@ -921,7 +927,8 @@
             "packages": [
                 "hollow",
                 "secinject",
-                "syscalls_shinject"
+                "syscalls_shinject",
+                "threadless-inject"
             ]
         },
         {

--- a/armory.json
+++ b/armory.json
@@ -872,6 +872,12 @@
             "command_name": "hashdump",
             "repo_url": "https://github.com/sliverarmory/hashdump",
             "public_key": "RWTh1yHjC7SqdX88YUPr0mwyWQpJPJf45rnquCfLl5McmSoxX1JMHvOG"
+        },
+        {
+            "name": "patchit",
+            "command_name": "patchit",
+            "repo_url": "https://github.com/sliverarmory/BOF-patchit",
+            "public_key": "RWQhRUp9UkE8nXlKTw+hpTg8fm0kJQpNDXy0gTpS/3Uw6+TPjM6jlxhy"
         }
     ],
     "bundles": [
@@ -906,7 +912,8 @@
             "packages": [
                 "inject-etw-bypass",
                 "inject-amsi-bypass",
-                "unhook-bof"
+                "unhook-bof",
+                "patchit"
             ]
         },
         {


### PR DESCRIPTION
Add 2 new BOF extensions:
- [patchit](https://github.com/sliverarmory/BOF-patchit) - patch, check and revert AMSI and ETW for x64
- [threadless-inject](https://github.com/sliverarmory/ThreadlessInject-BOF) - process injection technique with no thread creation, released at BSides Cymru 2023